### PR TITLE
API Changes & Verification Redirection

### DIFF
--- a/lib/config/constants/app_urls.dart
+++ b/lib/config/constants/app_urls.dart
@@ -13,5 +13,5 @@ class AppURLs {
   static const String login = "$baseAPI/login/";
   static const String accountStatus = "$baseAPI/account_status/";
   static const String verifyEmail = "$baseAPI/signup_verify_mobile/";
-  static const String resendOTP = "$baseAPI/regenerate_otp/";
+  static const String resendOTP = "$baseAPI/regenerate_email_otp/";
 }

--- a/lib/config/routes/router.dart
+++ b/lib/config/routes/router.dart
@@ -44,9 +44,9 @@ class AppRouter {
           return BlocProvider<VerifyEmailBloc>(
             create: (context) => VerifyEmailBloc(
               VerifyEmailRepository(),
-              email: _verifyEmailArguments.email,
+              username: _verifyEmailArguments.username,
             ),
-            child: VerifyEmail(),
+            child: const VerifyEmail(),
           );
         });
       case '/signIn':

--- a/lib/core/common/models/account_status_response.dart
+++ b/lib/core/common/models/account_status_response.dart
@@ -1,3 +1,5 @@
+import 'package:bitecope/config/utils/extensions/map_extension.dart';
+
 class AccountStatusResponse {
   bool status;
   int? userType;
@@ -25,7 +27,7 @@ class AccountStatusResponse {
       activeStatus: map['Active_Status'] as bool?,
       ownerStatus: _parseTypeStatus(map['Owner_Status']),
       workerStatus: _parseTypeStatus(map['Worker_Status']),
-      error: map['Error'] as String?,
+      error: map['statusCode'] as int >= 400 ? map.getMessage() : null,
     );
   }
 

--- a/lib/modules/sign_in/models/signin_reponse_model.dart
+++ b/lib/modules/sign_in/models/signin_reponse_model.dart
@@ -1,6 +1,8 @@
 // Dart imports:
 import 'dart:convert';
 
+import 'package:bitecope/config/utils/extensions/map_extension.dart';
+
 class SignInResponseModel {
   bool status;
   String? expiresIn;
@@ -19,7 +21,7 @@ class SignInResponseModel {
       status: map['statusCode'] as int < 300,
       token: map['Token'] != null ? map['Token'] as String : null,
       expiresIn: map['Expires_in'] != null ? map['Expires_in'] as String : null,
-      error: map['Error'] != null ? map['Error'] as String : null,
+      error: map['statusCode'] as int >= 400 ? map.getMessage() : null,
     );
   }
 

--- a/lib/modules/sign_in/screens/email_not_verified.dart
+++ b/lib/modules/sign_in/screens/email_not_verified.dart
@@ -1,4 +1,5 @@
 // Flutter imports:
+import 'package:bitecope/modules/verify_email/screens/verify_email.dart';
 import 'package:flutter/material.dart';
 
 // Package imports:
@@ -8,10 +9,11 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:bitecope/config/themes/theme.dart';
 import 'package:bitecope/widgets/gradient_widget.dart';
 import 'package:bitecope/widgets/rounded_wide_button.dart';
-import 'package:bitecope/widgets/snackbar_message.dart';
 
 class EmailNotVerified extends StatelessWidget {
-  const EmailNotVerified({Key? key}) : super(key: key);
+  final String username;
+
+  const EmailNotVerified({Key? key, required this.username}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -58,12 +60,11 @@ class EmailNotVerified extends StatelessWidget {
                 child: Center(
                   child: RoundedWideButton(
                     onTap: () {
-                      //TODO push to verifyEmail
-                      snackbarMessage(
-                        context,
-                        "Not Implemented Yet",
-                        MessageType.warning,
-                      );
+                      Navigator.of(context).pushNamedAndRemoveUntil(
+                          '/verifyEmail', ModalRoute.withName('/'),
+                          arguments: VerifyEmailArguments(
+                            username: username,
+                          ));
                     },
                     child: GradientWidget(
                       gradient: AppGradients.primaryGradient,

--- a/lib/modules/sign_in/screens/sign_in.dart
+++ b/lib/modules/sign_in/screens/sign_in.dart
@@ -70,7 +70,7 @@ class _SignInState extends State<SignIn> {
             ),
             child: BlocConsumer<SignInBloc, SignInState>(
               listener: (context, state) {
-                _handleListen(context, state.signInStatus);
+                _handleListen(context, state);
               },
               builder: (context, state) {
                 return Column(
@@ -168,25 +168,23 @@ class _SignInState extends State<SignIn> {
     );
   }
 
-  void _handleListen(BuildContext context, SignInStatus status) {
-    switch (status) {
+  void _handleListen(BuildContext context, SignInState state) {
+    switch (state.signInStatus) {
       case SignInStatus.signIn:
       case SignInStatus.signingIn:
         break;
       case SignInStatus.verify:
         Navigator.of(context).push(MaterialPageRoute(
-          builder: (context) => const EmailNotVerified(),
+          builder: (context) =>
+              EmailNotVerified(username: state.username.value!),
         ));
         break;
       case SignInStatus.activate:
-        //TODO Push to owner subscription
-        break;
+      //TODO Push to owner activation and break
       case SignInStatus.ownerInitialize:
-        //TODO Push to owner initialize
-        break;
+      //TODO Push to owner initialize and break
       case SignInStatus.workerInitialize:
-        //TODO Push to worker initialize
-        break;
+      //TODO Push to worker initialize and break
       case SignInStatus.signedIn:
         Navigator.of(context)
             .pushNamedAndRemoveUntil('/home', ModalRoute.withName('/'));

--- a/lib/modules/sign_up/screens/sign_up_two.dart
+++ b/lib/modules/sign_up/screens/sign_up_two.dart
@@ -68,7 +68,7 @@ class _SignUpTwoState extends State<SignUpTwo> {
             Navigator.of(context).pushNamedAndRemoveUntil(
                 '/verifyEmail', ModalRoute.withName('/'),
                 arguments: VerifyEmailArguments(
-                  email: state.email.value!,
+                  username: state.username.value!,
                 ));
           }
         },

--- a/lib/modules/verify_email/bloc/verify_email_state.dart
+++ b/lib/modules/verify_email/bloc/verify_email_state.dart
@@ -1,14 +1,14 @@
 part of 'verify_email_bloc.dart';
 
 class VerifyEmailState with EquatableMixin {
-  String email;
+  String username;
   late final BlocFormField<String> otp;
   int? timeout;
   VerifyEmailStatus verifyEmailStatus;
   ResendOTPStatus resendOTPStatus;
 
   VerifyEmailState({
-    required this.email,
+    required this.username,
     BlocFormField<String>? otp,
     this.timeout,
     this.verifyEmailStatus = VerifyEmailStatus.verify,
@@ -19,7 +19,7 @@ class VerifyEmailState with EquatableMixin {
 
   @override
   List<Object?> get props => [
-        email,
+        username,
         otp,
         timeout,
         verifyEmailStatus,
@@ -27,14 +27,14 @@ class VerifyEmailState with EquatableMixin {
       ];
 
   VerifyEmailState copyWith({
-    String? email,
+    String? username,
     BlocFormField<String>? otp,
     int? timeout,
     VerifyEmailStatus? verifyEmailStatus,
     ResendOTPStatus? resendOTPStatus,
   }) {
     return VerifyEmailState(
-      email: email ?? this.email,
+      username: username ?? this.username,
       otp: otp ?? this.otp,
       timeout: timeout == null ? this.timeout : (timeout <= 0 ? null : timeout),
       verifyEmailStatus: verifyEmailStatus ?? this.verifyEmailStatus,

--- a/lib/modules/verify_email/models/resend_otp_request.dart
+++ b/lib/modules/verify_email/models/resend_otp_request.dart
@@ -1,13 +1,13 @@
 class ResendOTPRequest {
-  String email;
+  String username;
 
   ResendOTPRequest({
-    required this.email,
+    required this.username,
   });
 
   Map<String, dynamic> toMap() {
     return {
-      'email_id': email,
+      'user_name': username,
     };
   }
 }

--- a/lib/modules/verify_email/repositories/verify_email_repository.dart
+++ b/lib/modules/verify_email/repositories/verify_email_repository.dart
@@ -26,9 +26,9 @@ class VerifyEmailRepository extends CommonRepository {
   }
 
   Future<ResendOTPResponse?> resendOTP({
-    required String email,
+    required String username,
   }) async {
-    final ResendOTPRequest request = ResendOTPRequest(email: email);
+    final ResendOTPRequest request = ResendOTPRequest(username: username);
     final Map<String, dynamic>? responseMap =
         await _verifyEmailProvider.resendOTP(request);
 

--- a/lib/modules/verify_email/screens/verify_email.dart
+++ b/lib/modules/verify_email/screens/verify_email.dart
@@ -21,16 +21,46 @@ import 'package:bitecope/widgets/snackbar_message.dart';
 import 'package:bitecope/widgets/underlined_title.dart';
 
 class VerifyEmailArguments {
-  String email;
+  String username;
 
-  VerifyEmailArguments({required this.email});
+  VerifyEmailArguments({required this.username});
 }
 
-class VerifyEmail extends StatelessWidget {
+class VerifyEmail extends StatefulWidget {
+  const VerifyEmail({Key? key}) : super(key: key);
+
+  @override
+  _VerifyEmailState createState() => _VerifyEmailState();
+}
+
+class _VerifyEmailState extends State<VerifyEmail> with WidgetsBindingObserver {
   final GlobalKey<FormState> _otpFormKey = GlobalKey<FormState>();
   final TextEditingController _otpController = TextEditingController();
+  bool _runStatusCheck = true;
 
-  VerifyEmail({Key? key}) : super(key: key);
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance?.addObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.resumed:
+        setState(() {
+          _runStatusCheck = true;
+        });
+        break;
+      case AppLifecycleState.detached:
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.paused:
+        setState(() {
+          _runStatusCheck = false;
+        });
+        break;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -52,6 +82,9 @@ class VerifyEmail extends StatelessWidget {
                         _handleListen(context, state);
                       },
                       builder: (context, state) {
+                        context
+                            .read<VerifyEmailBloc>()
+                            .checkStatus(run: _runStatusCheck);
                         return Column(
                           mainAxisSize: MainAxisSize.min,
                           children: [
@@ -269,5 +302,11 @@ class VerifyEmail extends StatelessWidget {
         );
       },
     );
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance?.removeObserver(this);
+    super.dispose();
   }
 }


### PR DESCRIPTION
#3 #9

- Request and response models changed to reflect the recent API changes.
- Email verification page now pings the server every 5 seconds to see if the user is verified, and redirects to success page automatically.
	- The ping happens only if the app is active; it is suspended if the app is in the background or inactive (screen goes off). This will ensure the app does not keep pinging the server perpetually.
- Verification does not work with regenerated OTP ; this is likely to be fixed when it is fixed in the backend.